### PR TITLE
feat: Add video screenshot extraction tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This MCP server provides comprehensive access to YouTube Data API v3 with additi
 - **🎨 Media**: Upload thumbnails and manage watermarks
 - **📊 Metadata**: Access categories, regions, and languages
 - **🤖 AI Analysis**: Analyze videos with Gemini AI
+- **📸 Screenshots**: Capture frames from videos at specific timestamps
 
 ### ✨ Key Features
 
@@ -28,6 +29,7 @@ This MCP server provides comprehensive access to YouTube Data API v3 with additi
 - **📡 Comprehensive YouTube API Coverage**: Complete implementation of YouTube Data API v3 - videos, channels, playlists, comments, captions, subscriptions, and more
 - **🧠 AI-Powered Video Analysis**: Gemini integration for video content analysis, Q&A, and transcript generation
 - **📄 Raw Transcript Support**: Extract existing YouTube transcripts via youtube-transcript-api without API quota usage
+- **📸 Video Screenshots**: Extract frames at specific timestamps without API quota usage
 
 ## Installation & Setup
 
@@ -161,6 +163,7 @@ Required:
 
 Optional:
 - `GEMINI_API_KEY`: API key for Gemini AI integration (only required if using Gemini tools)
+- `YOUTUBE_SCREENSHOT_DEFAULT_QUALITY`: Default video quality for screenshots (144p, 240p, 360p, 480p, 720p, 1080p, best) - defaults to 1080p
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
     "google>=3.0.0,<4",
     "google-genai>=0.1.0,<0.2",
     "psutil>=7.0.0,<8",
+    "yt-dlp>=2024.1.0",
+    "opencv-python>=4.8.0,<5",
 ]
 
 [project.scripts]

--- a/src/config.py
+++ b/src/config.py
@@ -16,6 +16,10 @@ class Config(BaseModel):
     gemini_model: str = Field(description="Default Gemini model to use")
     gemini_api_key: Optional[str] = Field(default=None, description="Gemini API key for AI integration")
     upload_state_dir: str = Field(description="Directory for storing upload state files")
+    screenshot_default_quality: Optional[str] = Field(
+        default=None, 
+        description="Default quality for video screenshots (144p, 240p, 360p, 480p, 720p, 1080p, best). Default: 1080p if not set"
+    )
     
     
     @classmethod
@@ -45,6 +49,7 @@ class Config(BaseModel):
             raw_transcript_lang=os.environ.get("YOUTUBE_RAW_TRANSCRIPT_LANG"),
             gemini_model=os.environ.get("GEMINI_MODEL"),
             gemini_api_key=os.environ.get("GEMINI_API_KEY"),
-            upload_state_dir=os.environ.get("YOUTUBE_UPLOAD_STATE_DIR")
+            upload_state_dir=os.environ.get("YOUTUBE_UPLOAD_STATE_DIR"),
+            screenshot_default_quality=os.environ.get("YOUTUBE_SCREENSHOT_DEFAULT_QUALITY")
         )
     

--- a/src/server.py
+++ b/src/server.py
@@ -12,7 +12,8 @@ from .services import (
     videos, channels, playlists, transcripts, subscriptions, search,
     captions, channel_banners, channel_sections, comments, comment_threads,
     members, memberships_levels, playlist_items, playlist_images,
-    thumbnails, video_categories, watermarks, i18n_regions, i18n_languages, gemini
+    thumbnails, video_categories, watermarks, i18n_regions, i18n_languages, gemini,
+    video_screenshots
 )
 from .utils import YouTubeClient
 
@@ -127,6 +128,9 @@ Metadata:
 Other:
 - transcripts_get_transcript: Get raw transcript/captions from YouTube (no auth required)
 
+Video Screenshots:
+- video_screenshot_at_timestamp: Capture screenshot from video at specific timestamp
+
 Gemini AI Integration:
 - gemini_analyze_youtube_video: Analyze YouTube videos using Gemini AI
 - gemini_compare_youtube_videos: Compare multiple YouTube videos (2-10)
@@ -137,6 +141,7 @@ Configuration:
 - CONFIG_DIR: Configuration directory containing client_secrets.json and token.json
 - YOUTUBE_RAW_TRANSCRIPT_LANG: Default language for raw transcripts (default: 'en')
 - YOUTUBE_UPLOAD_STATE_DIR: Directory for upload state files (default: '/tmp/pmind-youtube-mcp-uploads')
+- YOUTUBE_SCREENSHOT_DEFAULT_QUALITY: Default quality for screenshots (144p/240p/360p/480p/720p/1080p/best, default: 1080p)
 - GEMINI_MODEL: Default Gemini model to use (default: 'gemini-2.5-flash')
 - GEMINI_API_KEY: API key for Gemini AI integration
 
@@ -178,6 +183,7 @@ OAuth Authentication:
     i18n_regions.register_tools(mcp, config, youtube_client)
     i18n_languages.register_tools(mcp, config, youtube_client)
     transcripts.register_tools(mcp, config)
+    video_screenshots.register_tools(mcp, config, youtube_client)
     gemini.register_tools(mcp, config)
     
     return mcp
@@ -221,6 +227,8 @@ def configure_interactive():
     if not gemini_model:
         gemini_model = "gemini-2.5-flash"
     
+    screenshot_quality = input("Default screenshot quality (144p/240p/360p/480p/720p/1080p/best) [1080p]: ").strip()
+    
     # Create directories
     print("\nCreating directories...")
     directories_to_create = set()
@@ -252,6 +260,12 @@ YOUTUBE_RAW_TRANSCRIPT_LANG={transcript_lang}
 
 # Directory for upload state files
 YOUTUBE_UPLOAD_STATE_DIR={upload_dir}
+"""
+    
+    if screenshot_quality:
+        env_content += f"""
+# Default quality for video screenshots
+YOUTUBE_SCREENSHOT_DEFAULT_QUALITY={screenshot_quality}
 """
     
     if gemini_key:

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -4,12 +4,14 @@ from . import (
     videos, channels, playlists, transcripts, subscriptions, search,
     captions, channel_banners, channel_sections, comments, comment_threads,
     members, memberships_levels, playlist_items, playlist_images,
-    thumbnails, video_categories, watermarks, i18n_regions, i18n_languages, gemini
+    thumbnails, video_categories, watermarks, i18n_regions, i18n_languages, gemini,
+    video_screenshots
 )
 
 __all__ = [
     "videos", "channels", "playlists", "transcripts", "subscriptions", "search",
     "captions", "channel_banners", "channel_sections", "comments", "comment_threads",
     "members", "memberships_levels", "playlist_items", "playlist_images",
-    "thumbnails", "video_categories", "watermarks", "i18n_regions", "i18n_languages", "gemini"
+    "thumbnails", "video_categories", "watermarks", "i18n_regions", "i18n_languages", "gemini",
+    "video_screenshots"
 ]

--- a/src/services/video_screenshots.py
+++ b/src/services/video_screenshots.py
@@ -1,0 +1,297 @@
+"""Video screenshot extraction tools for capturing frames at specific timestamps"""
+
+import re
+import base64
+from pathlib import Path
+from typing import Dict, Any, Optional, List, Union, Annotated, Literal
+from pydantic import Field
+import cv2
+import yt_dlp
+from fastmcp import FastMCP
+from ..config import Config
+from ..utils import YouTubeClient
+
+
+def parse_timestamp(timestamp: Union[str, int, float]) -> float:
+    """
+    Parse timestamp in various formats to seconds.
+    
+    Supported formats:
+    - Integer/float: direct seconds (e.g., 90, 90.5)
+    - String seconds: "90", "90.5"
+    - HH:MM:SS format: "1:30:45"
+    - MM:SS format: "2:30"
+    - With decimal seconds: "1:30:45.5"
+    """
+    if isinstance(timestamp, (int, float)):
+        return float(timestamp)
+    
+    if isinstance(timestamp, str):
+        # Try to parse as simple number first
+        try:
+            return float(timestamp)
+        except ValueError:
+            pass
+        
+        # Parse time format HH:MM:SS or MM:SS
+        time_pattern = r'^(?:(\d+):)?(\d+):(\d+(?:\.\d+)?)$'
+        match = re.match(time_pattern, timestamp)
+        
+        if match:
+            hours = int(match.group(1) or 0)
+            minutes = int(match.group(2))
+            seconds = float(match.group(3))
+            return hours * 3600 + minutes * 60 + seconds
+        
+        raise ValueError(f"Invalid timestamp format: {timestamp}")
+
+
+def register_tools(mcp: FastMCP, config: Config, youtube_client: YouTubeClient):
+    """Register video screenshot tools with the MCP server"""
+    
+    @mcp.tool
+    async def video_screenshot_at_timestamp(
+        video_id: Annotated[str, Field(
+            description="YouTube video ID or full URL"
+        )],
+        timestamp: Annotated[Union[str, int, float], Field(
+            description="Timestamp to capture (seconds, 'MM:SS', or 'HH:MM:SS')"
+        )],
+        output_format: Annotated[Literal["file", "base64"], Field(
+            default="file",
+            description="Return format: 'file' saves to disk, 'base64' returns encoded image"
+        )] = "file",
+        quality: Annotated[Optional[str], Field(
+            default=None,
+            description="Video quality to use (144p, 240p, 360p, 480p, 720p, 1080p, best). Default: config value or 1080p"
+        )] = None,
+        output_path: Annotated[Optional[str], Field(
+            default=None,
+            description="Custom output path for file format (default: CONFIG_DIR/screenshots)"
+        )] = None,
+        image_format: Annotated[Literal["jpg", "png"], Field(
+            default="jpg",
+            description="Image format for the screenshot"
+        )] = "jpg"
+    ) -> Dict[str, Any]:
+        """
+        Capture a screenshot from a YouTube video at a specific timestamp.
+        
+        This tool downloads the video stream and extracts a frame at the specified time.
+        Does not require YouTube API authentication.
+        
+        Examples:
+        - timestamp="30" or timestamp=30 - capture at 30 seconds
+        - timestamp="1:30" - capture at 1 minute 30 seconds  
+        - timestamp="1:15:30" - capture at 1 hour 15 minutes 30 seconds
+        - timestamp="90.5" - capture at 90.5 seconds
+        
+        Returns:
+        - For 'file' format: path to saved image
+        - For 'base64' format: base64 encoded image data
+        """
+        try:
+            # Extract video ID from URL if needed
+            if "youtube.com" in video_id or "youtu.be" in video_id:
+                # Extract ID from URL using regex
+                patterns = [
+                    r'youtube\.com/watch\?v=([^&]+)',
+                    r'youtu\.be/([^?]+)',
+                    r'youtube\.com/embed/([^?]+)'
+                ]
+                for pattern in patterns:
+                    match = re.search(pattern, video_id)
+                    if match:
+                        video_id = match.group(1)
+                        break
+            
+            # Parse timestamp to seconds
+            try:
+                target_seconds = parse_timestamp(timestamp)
+            except ValueError as e:
+                return {
+                    "error": "Invalid timestamp format",
+                    "details": str(e),
+                    "supported_formats": [
+                        "Seconds: 30, 90.5",
+                        "String seconds: '30', '90.5'", 
+                        "MM:SS format: '1:30'",
+                        "HH:MM:SS format: '1:15:30'"
+                    ]
+                }
+            
+            # Configure yt-dlp options
+            ydl_opts = {
+                'quiet': True,
+                'no_warnings': True,
+                'no_color': True,
+            }
+            
+            # Get video info without downloading
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                video_url = f"https://www.youtube.com/watch?v={video_id}"
+                try:
+                    info_dict = ydl.extract_info(video_url, download=False)
+                except Exception as e:
+                    return {
+                        "error": "Failed to fetch video information",
+                        "details": str(e),
+                        "video_id": video_id
+                    }
+                
+                # Check if timestamp is within video duration
+                duration = info_dict.get('duration', 0)
+                if target_seconds > duration:
+                    return {
+                        "error": "Timestamp exceeds video duration",
+                        "details": f"Requested {target_seconds}s but video is only {duration}s long",
+                        "video_duration": duration,
+                        "requested_timestamp": target_seconds
+                    }
+                
+                # Get available formats
+                formats = info_dict.get('formats', [])
+                
+                # Filter and select format based on quality preference
+                video_formats = [f for f in formats if f.get('vcodec') != 'none']
+                
+                # Use config default if quality not specified
+                if not quality:
+                    if config.screenshot_default_quality:
+                        quality = config.screenshot_default_quality
+                    else:
+                        # Default to 1080p if no config set
+                        quality = "1080p"
+                
+                selected_format = None
+                if quality:
+                    # Map quality to height
+                    quality_map = {
+                        '144p': 144, '240p': 240, '360p': 360,
+                        '480p': 480, '720p': 720, '1080p': 1080
+                    }
+                    
+                    if quality == 'best':
+                        # Select highest quality
+                        selected_format = max(video_formats, 
+                                             key=lambda x: x.get('height', 0))
+                    elif quality in quality_map:
+                        target_height = quality_map[quality]
+                        # Find closest quality
+                        for fmt in video_formats:
+                            if fmt.get('height') == target_height:
+                                selected_format = fmt
+                                break
+                        
+                        # If exact match not found, get closest lower quality
+                        if not selected_format:
+                            lower_formats = [f for f in video_formats 
+                                           if f.get('height', 0) <= target_height]
+                            if lower_formats:
+                                selected_format = max(lower_formats,
+                                                    key=lambda x: x.get('height', 0))
+                
+                # Default to lowest quality for speed if not specified
+                if not selected_format:
+                    selected_format = min(video_formats,
+                                        key=lambda x: x.get('height', 0))
+                
+                stream_url = selected_format.get('url')
+                if not stream_url:
+                    return {
+                        "error": "No suitable video stream found",
+                        "details": "Could not find a valid video URL"
+                    }
+                
+                # Open video capture
+                cap = cv2.VideoCapture(stream_url)
+                try:
+                    if not cap.isOpened():
+                        return {
+                            "error": "Failed to open video stream",
+                            "details": "Could not access the video URL"
+                        }
+                    
+                    # Get FPS and calculate frame number
+                    fps = cap.get(cv2.CAP_PROP_FPS)
+                    if fps <= 0:
+                        fps = 30  # Default fallback
+                    
+                    target_frame = int(fps * target_seconds)
+                    
+                    # Seek to target frame
+                    cap.set(cv2.CAP_PROP_POS_FRAMES, target_frame)
+                    
+                    # Read the frame
+                    ret, frame = cap.read()
+                    
+                    if not ret or frame is None:
+                        return {
+                            "error": "Failed to capture frame",
+                            "details": f"Could not read frame at {target_seconds}s"
+                        }
+                finally:
+                    cap.release()
+                
+                # Prepare output
+                if output_format == "file":
+                    # Determine output directory
+                    if output_path:
+                        output_dir = Path(output_path).parent
+                        output_file = Path(output_path)
+                    else:
+                        output_dir = Path(config.config_dir) / "screenshots"
+                        output_dir.mkdir(parents=True, exist_ok=True)
+                        
+                        # Generate filename
+                        safe_title = re.sub(r'[^\w\s-]', '', info_dict.get('title', video_id))
+                        safe_title = re.sub(r'[-\s]+', '-', safe_title)[:50]
+                        timestamp_str = str(target_seconds).replace('.', '_')
+                        filename = f"{safe_title}_{timestamp_str}s.{image_format}"
+                        output_file = output_dir / filename
+                    
+                    # Save image
+                    if image_format == "jpg":
+                        cv2.imwrite(str(output_file), frame, 
+                                  [cv2.IMWRITE_JPEG_QUALITY, 95])
+                    else:  # png
+                        cv2.imwrite(str(output_file), frame)
+                    
+                    return {
+                        "success": True,
+                        "video_id": video_id,
+                        "video_title": info_dict.get('title', 'Unknown'),
+                        "timestamp": target_seconds,
+                        "timestamp_formatted": timestamp,
+                        "output_path": str(output_file),
+                        "resolution": f"{frame.shape[1]}x{frame.shape[0]}",
+                        "quality_used": f"{selected_format.get('height', 'unknown')}p"
+                    }
+                    
+                else:  # base64
+                    # Encode image to base64
+                    if image_format == "jpg":
+                        _, buffer = cv2.imencode('.jpg', frame,
+                                               [cv2.IMWRITE_JPEG_QUALITY, 95])
+                    else:  # png
+                        _, buffer = cv2.imencode('.png', frame)
+                    
+                    image_base64 = base64.b64encode(buffer).decode('utf-8')
+                    
+                    return {
+                        "success": True,
+                        "video_id": video_id,
+                        "video_title": info_dict.get('title', 'Unknown'),
+                        "timestamp": target_seconds,
+                        "timestamp_formatted": timestamp,
+                        "image_data": image_base64,
+                        "image_format": image_format,
+                        "resolution": f"{frame.shape[1]}x{frame.shape[0]}",
+                        "quality_used": f"{selected_format.get('height', 'unknown')}p"
+                    }
+                    
+        except Exception as e:
+            return {
+                "error": f"Unexpected error: {type(e).__name__}",
+                "details": str(e)
+            }

--- a/uv.lock
+++ b/uv.lock
@@ -552,6 +552,44 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff", size = 20875348, upload-time = "2025-05-17T21:34:39.648Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c", size = 14119362, upload-time = "2025-05-17T21:35:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3", size = 5084103, upload-time = "2025-05-17T21:35:10.622Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282", size = 6625382, upload-time = "2025-05-17T21:35:21.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87", size = 14018462, upload-time = "2025-05-17T21:35:42.174Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249", size = 16527618, upload-time = "2025-05-17T21:36:06.711Z" },
+    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49", size = 15505511, upload-time = "2025-05-17T21:36:29.965Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de", size = 18313783, upload-time = "2025-05-17T21:36:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4", size = 6246506, upload-time = "2025-05-17T21:37:07.368Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2", size = 12614190, upload-time = "2025-05-17T21:37:26.213Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5c/6657823f4f594f72b5471f1db1ab12e26e890bb2e41897522d134d2a3e81/numpy-2.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0811bb762109d9708cca4d0b13c4f67146e3c3b7cf8d34018c722adb2d957c84", size = 20867828, upload-time = "2025-05-17T21:37:56.699Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9e/14520dc3dadf3c803473bd07e9b2bd1b69bc583cb2497b47000fed2fa92f/numpy-2.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:287cc3162b6f01463ccd86be154f284d0893d2b3ed7292439ea97eafa8170e0b", size = 14143006, upload-time = "2025-05-17T21:38:18.291Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/06/7e96c57d90bebdce9918412087fc22ca9851cceaf5567a45c1f404480e9e/numpy-2.2.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f1372f041402e37e5e633e586f62aa53de2eac8d98cbfb822806ce4bbefcb74d", size = 5076765, upload-time = "2025-05-17T21:38:27.319Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ed/63d920c23b4289fdac96ddbdd6132e9427790977d5457cd132f18e76eae0/numpy-2.2.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:55a4d33fa519660d69614a9fad433be87e5252f4b03850642f88993f7b2ca566", size = 6617736, upload-time = "2025-05-17T21:38:38.141Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c5/e19c8f99d83fd377ec8c7e0cf627a8049746da54afc24ef0a0cb73d5dfb5/numpy-2.2.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f92729c95468a2f4f15e9bb94c432a9229d0d50de67304399627a943201baa2f", size = 14010719, upload-time = "2025-05-17T21:38:58.433Z" },
+    { url = "https://files.pythonhosted.org/packages/19/49/4df9123aafa7b539317bf6d342cb6d227e49f7a35b99c287a6109b13dd93/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc23a79bfabc5d056d106f9befb8d50c31ced2fbc70eedb8155aec74a45798f", size = 16526072, upload-time = "2025-05-17T21:39:22.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6c/04b5f47f4f32f7c2b0e7260442a8cbcf8168b0e1a41ff1495da42f42a14f/numpy-2.2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3143e4451880bed956e706a3220b4e5cf6172ef05fcc397f6f36a550b1dd868", size = 15503213, upload-time = "2025-05-17T21:39:45.865Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0a/5cd92e352c1307640d5b6fec1b2ffb06cd0dabe7d7b8227f97933d378422/numpy-2.2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4f13750ce79751586ae2eb824ba7e1e8dba64784086c98cdbbcc6a42112ce0d", size = 18316632, upload-time = "2025-05-17T21:40:13.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3b/5cba2b1d88760ef86596ad0f3d484b1cbff7c115ae2429678465057c5155/numpy-2.2.6-cp313-cp313-win32.whl", hash = "sha256:5beb72339d9d4fa36522fc63802f469b13cdbe4fdab4a288f0c441b74272ebfd", size = 6244532, upload-time = "2025-05-17T21:43:46.099Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/3b/d58c12eafcb298d4e6d0d40216866ab15f59e55d148a5658bb3132311fcf/numpy-2.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b0544343a702fa80c95ad5d3d608ea3599dd54d4632df855e4c8d24eb6ecfa1c", size = 12610885, upload-time = "2025-05-17T21:44:05.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/9e/4bf918b818e516322db999ac25d00c75788ddfd2d2ade4fa66f1f38097e1/numpy-2.2.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0bca768cd85ae743b2affdc762d617eddf3bcf8724435498a1e80132d04879e6", size = 20963467, upload-time = "2025-05-17T21:40:44Z" },
+    { url = "https://files.pythonhosted.org/packages/61/66/d2de6b291507517ff2e438e13ff7b1e2cdbdb7cb40b3ed475377aece69f9/numpy-2.2.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fc0c5673685c508a142ca65209b4e79ed6740a4ed6b2267dbba90f34b0b3cfda", size = 14225144, upload-time = "2025-05-17T21:41:05.695Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/25/480387655407ead912e28ba3a820bc69af9adf13bcbe40b299d454ec011f/numpy-2.2.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:5bd4fc3ac8926b3819797a7c0e2631eb889b4118a9898c84f585a54d475b7e40", size = 5200217, upload-time = "2025-05-17T21:41:15.903Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4a/6e313b5108f53dcbf3aca0c0f3e9c92f4c10ce57a0a721851f9785872895/numpy-2.2.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:fee4236c876c4e8369388054d02d0e9bb84821feb1a64dd59e137e6511a551f8", size = 6712014, upload-time = "2025-05-17T21:41:27.321Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/30/172c2d5c4be71fdf476e9de553443cf8e25feddbe185e0bd88b096915bcc/numpy-2.2.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1dda9c7e08dc141e0247a5b8f49cf05984955246a327d4c48bda16821947b2f", size = 14077935, upload-time = "2025-05-17T21:41:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fb/9e743f8d4e4d3c710902cf87af3512082ae3d43b945d5d16563f26ec251d/numpy-2.2.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f447e6acb680fd307f40d3da4852208af94afdfab89cf850986c3ca00562f4fa", size = 16600122, upload-time = "2025-05-17T21:42:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/12/75/ee20da0e58d3a66f204f38916757e01e33a9737d0b22373b3eb5a27358f9/numpy-2.2.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:389d771b1623ec92636b0786bc4ae56abafad4a4c513d36a55dce14bd9ce8571", size = 15586143, upload-time = "2025-05-17T21:42:37.464Z" },
+    { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260, upload-time = "2025-05-17T21:43:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225, upload-time = "2025-05-17T21:43:16.254Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374, upload-time = "2025-05-17T21:43:35.479Z" },
+]
+
+[[package]]
 name = "oauthlib"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -570,6 +608,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "opencv-python"
+version = "4.12.0.88"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/71/25c98e634b6bdeca4727c7f6d6927b056080668c5008ad3c8fc9e7f8f6ec/opencv-python-4.12.0.88.tar.gz", hash = "sha256:8b738389cede219405f6f3880b851efa3415ccd674752219377353f017d2994d", size = 95373294, upload-time = "2025-07-07T09:20:52.389Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/68/3da40142e7c21e9b1d4e7ddd6c58738feb013203e6e4b803d62cdd9eb96b/opencv_python-4.12.0.88-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:f9a1f08883257b95a5764bf517a32d75aec325319c8ed0f89739a57fae9e92a5", size = 37877727, upload-time = "2025-07-07T09:13:31.47Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7c/042abe49f58d6ee7e1028eefc3334d98ca69b030e3b567fe245a2b28ea6f/opencv_python-4.12.0.88-cp37-abi3-macosx_13_0_x86_64.whl", hash = "sha256:812eb116ad2b4de43ee116fcd8991c3a687f099ada0b04e68f64899c09448e81", size = 57326471, upload-time = "2025-07-07T09:13:41.26Z" },
+    { url = "https://files.pythonhosted.org/packages/62/3a/440bd64736cf8116f01f3b7f9f2e111afb2e02beb2ccc08a6458114a6b5d/opencv_python-4.12.0.88-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:51fd981c7df6af3e8f70b1556696b05224c4e6b6777bdd2a46b3d4fb09de1a92", size = 45887139, upload-time = "2025-07-07T09:13:50.761Z" },
+    { url = "https://files.pythonhosted.org/packages/68/1f/795e7f4aa2eacc59afa4fb61a2e35e510d06414dd5a802b51a012d691b37/opencv_python-4.12.0.88-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:092c16da4c5a163a818f120c22c5e4a2f96e0db4f24e659c701f1fe629a690f9", size = 67041680, upload-time = "2025-07-07T09:14:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/02/96/213fea371d3cb2f1d537612a105792aa0a6659fb2665b22cad709a75bd94/opencv_python-4.12.0.88-cp37-abi3-win32.whl", hash = "sha256:ff554d3f725b39878ac6a2e1fa232ec509c36130927afc18a1719ebf4fbf4357", size = 30284131, upload-time = "2025-07-07T09:14:08.819Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/80/eb88edc2e2b11cd2dd2e56f1c80b5784d11d6e6b7f04a1145df64df40065/opencv_python-4.12.0.88-cp37-abi3-win_amd64.whl", hash = "sha256:d98edb20aa932fd8ebd276a72627dad9dc097695b3d435a4257557bbb49a79d2", size = 39000307, upload-time = "2025-07-07T09:14:16.641Z" },
 ]
 
 [[package]]
@@ -626,10 +681,12 @@ dependencies = [
     { name = "google-api-python-client" },
     { name = "google-auth-oauthlib" },
     { name = "google-genai" },
+    { name = "opencv-python" },
     { name = "psutil" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "youtube-transcript-api" },
+    { name = "yt-dlp" },
 ]
 
 [package.metadata]
@@ -639,10 +696,12 @@ requires-dist = [
     { name = "google-api-python-client", specifier = ">=2.176.0,<3" },
     { name = "google-auth-oauthlib", specifier = ">=1.2.2,<2" },
     { name = "google-genai", specifier = ">=0.1.0,<0.2" },
+    { name = "opencv-python", specifier = ">=4.8.0,<5" },
     { name = "psutil", specifier = ">=7.0.0,<8" },
     { name = "pydantic", specifier = ">=2.11.7,<3" },
     { name = "python-dotenv", specifier = ">=1.1.1,<2" },
     { name = "youtube-transcript-api", specifier = ">=1.1.1,<2" },
+    { name = "yt-dlp", specifier = ">=2024.1.0" },
 ]
 
 [[package]]
@@ -1113,4 +1172,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e5/226a09b9ca49136f901a969fd65bcd055eaa980fd04ac065dac4741e6b00/youtube_transcript_api-1.1.1.tar.gz", hash = "sha256:2e1162d45ece14223a58a4a39176c464fdd33d5ebdd6def18ebb038dea62f667", size = 470360, upload-time = "2025-07-03T13:43:23.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/8a/b942a230084045da4a255bbebca97693569535670c0a23c09096881b2846/youtube_transcript_api-1.1.1-py3-none-any.whl", hash = "sha256:a438a824d67c0885855047e2b38993abdd4f59b69a983cf27b50a06c9d564064", size = 485906, upload-time = "2025-07-03T13:43:22.806Z" },
+]
+
+[[package]]
+name = "yt-dlp"
+version = "2025.7.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/3a/343f7a0024ddd4c30f150e8d8f57fd7b924846f97d99fc0dcd75ea8d2773/yt_dlp-2025.7.21.tar.gz", hash = "sha256:46fbb53eab1afbe184c45b4c17e9a6eba614be680e4c09de58b782629d0d7f43", size = 3050219, upload-time = "2025-07-21T23:59:03.826Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2f/abe59a3204c749fed494849ea29176bcefa186ec8898def9e43f649ddbcf/yt_dlp-2025.7.21-py3-none-any.whl", hash = "sha256:d7aa2b53f9b2f35453346360f41811a0dad1e956e70b35a4ae95039d4d815d15", size = 3288681, upload-time = "2025-07-21T23:59:01.788Z" },
 ]


### PR DESCRIPTION
- Add new video_screenshot_at_timestamp tool to capture frames from YouTube videos
- Support multiple timestamp formats (seconds, MM:SS, HH:MM:SS)
- Allow output as file or base64 encoded image
- Add configurable default quality setting (YOUTUBE_SCREENSHOT_DEFAULT_QUALITY)
- Support multiple video quality options (144p to 1080p or best)
- Update README with screenshot tool documentation
- Add yt-dlp and opencv-python dependencies

The tool extracts frames without using YouTube API quota by leveraging yt-dlp for video stream access and OpenCV for frame capture.

🤖 Generated with [Claude Code](https://claude.ai/code)